### PR TITLE
Missing named arguments

### DIFF
--- a/articles/data-factory/quickstart-create-data-factory-python.md
+++ b/articles/data-factory/quickstart-create-data-factory-python.md
@@ -374,9 +374,9 @@ def main():
     act_name = 'copyBlobtoBlob'
     blob_source = BlobSource()
     blob_sink = BlobSink()
-    dsin_ref = DatasetReference(ds_name)
-    dsOut_ref = DatasetReference(dsOut_name)
-    copy_activity = CopyActivity(act_name, inputs=[dsin_ref], outputs=[
+    dsin_ref = DatasetReference(reference_name=ds_name)
+    dsOut_ref = DatasetReference(reference_name=dsOut_name)
+    copy_activity = CopyActivity(name=act_name, inputs=[dsin_ref], outputs=[
                                  dsOut_ref], source=blob_source, sink=blob_sink)
 
     # Create a pipeline with the copy activity


### PR DESCRIPTION
"reference_name=" for DatasetReference;
"name="for CopyActivity
These were correct in the smaller snippets, but not for the "Full Script" block